### PR TITLE
resurrect shebang line.

### DIFF
--- a/roswell/sblint.ros
+++ b/roswell/sblint.ros
@@ -1,3 +1,4 @@
+#!/bin/sh
 #|-*- mode:lisp -*-|#
 #| A linter for Common Lisp source code using SBCL
 exec ros -Q -- $0 "$@"


### PR DESCRIPTION
I'm using sblint with eshell.
without shebang line It shows

```
emacs: /Users/snmsts/.roswell/bin/sblint: Exec format error
```

so this patch will fix it.
