### PR TITLE
Run sblint.ros under SBCL, even if `ros use ccl-bin`

### DIFF
--- a/roswell/sblint.ros
+++ b/roswell/sblint.ros
@@ -1,7 +1,7 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #| A linter for Common Lisp source code using SBCL
-exec ros -Q -- $0 "$@"
+exec ros -Q -L sbcl-bin -- $0 "$@"
 |#
 #-sbcl
 (error "SBLint requires SBCL. Make sure it is installed with `ros install sbcl' and use it with `ros use sbcl'.")


### PR DESCRIPTION
This PR makes `sblint.ros` running under SBCL even after I typed like `ros use ccl-bin`.

SBCL's lint functionality is pretty good, so this project is very nice. Because of that, I usually use SBCL. However I want to use CCL usually. So I want to run `sblint.ros` under SBCL with any default CL implementations.