### PR TITLE
Document cli options in sblint

### DIFF
--- a/roswell/sblint.ros
+++ b/roswell/sblint.ros
@@ -32,7 +32,10 @@ exec ros -Q -L sbcl-bin -- $0 "$@"
    "SBLint v~A.
 Usage:
     $ sblint # runs on all ASD files in current directory
-    $ sblint [directories or files...]"
+    $ sblint [directories or files...]
+Options:
+    -v|--verbose: Provide verbose log output
+    -h|--help: Print this help message and exit"
    (asdf:component-version (asdf:find-system :sblint))))
 
 (defun main (&rest argv)


### PR DESCRIPTION
This PR updates the message printed by `print-usage` to include the option strings. I personally had to inspect the source to find out about the option `-v|--verbose`, and since it’s pretty useful I think it should be documented by the output of `--help`.

Thanks for the linter!

Cheers