### PR TITLE
Now sblint command exits with nonzero exit code

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -7,7 +7,9 @@ if [ -z "$(which sblint)" ]; then
     exit 0
 fi
 
-error_count=$(sblint | wc -l | tr -d '[[:space:]]')
+sblint
+
+error_count=$?
 
 if [ "$error_count" -gt "0" ]; then
     echo "Failed to commit because $error_count errors are found by SBLint."

--- a/roswell/sblint.ros
+++ b/roswell/sblint.ros
@@ -61,9 +61,10 @@ Options:
                          (lambda (e)
                            (uiop:print-condition-backtrace e :stream stream))))
           (handler-case
-              (if (uiop:file-pathname-p target)
-                  (run-lint-file target)
-                  (run-lint-directory target))
+              (uiop:quit
+                (if (uiop:file-pathname-p target)
+                    (run-lint-file target)
+                    (run-lint-directory target)))
             (sblint:sblint-error (e)
               (print-error "~A" e))))))))
 


### PR DESCRIPTION
This makes it more useful in CI pipelines.

Now it returns a number of found errors:

```bash
[art@poftheday] qlot exec sblint
src/appenders.lisp:41:0: style-warning: The variable B is defined but never used.
src/appenders.lisp:46:2: simple-warning: The function FOO is called with zero arguments, but wants exactly two.
src/appenders.lisp:50:2: type-warning: Constant 3.14 conflicts with its asserted type FIXNUM.
WARNING: Compilation failed in a system "log4cl-extras".
[art@poftheday] echo $?
```